### PR TITLE
Make integration installable via HACS (Home Assistant Community Store) by adding hacs.json

### DIFF
--- a/hacs.json
+++ b/hacs.json
@@ -1,0 +1,6 @@
+  {
+    "name": "Nature Remo",
+    "content_in_root": false,
+    "render_readme": true,
+    "homeassistant": "2023.1.0"
+  }


### PR DESCRIPTION
There is a full GUI way to install custom integration by using HACS. Currently when trying to add this repository via HACS, I got this error message "The version v0.2.0 for this integration can not be used with HACS." 

I believe this error is only cause by the missing hacs.json file. Therefore I propose adding this file, and releasing a version with it to make it fully compatible with HACS.

Some links for HACS:
[HACS Home page](https://www.hacs.xyz/)
[hacs.json requirement](https://www.hacs.xyz/docs/publish/start/#hacsjson)

Thanks a lot for your work. 