### PR TITLE
Add support for turn on/off in climate device

### DIFF
--- a/custom_components/nature_remo/climate.py
+++ b/custom_components/nature_remo/climate.py
@@ -111,6 +111,9 @@ class NatureRemoClimate(ClimateEntity):
             # self.hassはasync_added_to_hass()以降にHAフレームワークが自動セットする
             self._entry_id = entry_id
 
+            # ClimateEntityFeature.TURN_ON / TURN_OFF は互換モードをオフを明示的に必要とする
+            self._enable_turn_on_off_backwards_compatibility = False
+
         except Exception as e:
             _LOGGER.error(f"Error initializing NatureRemoClimate: {e}")
 
@@ -127,7 +130,11 @@ class NatureRemoClimate(ClimateEntity):
     def supported_features(self) -> int:
         """対応している機能を定義. / Define the features supported by this entity."""
         _LOGGER.debug(f"[{self._attr_name}] Start supported_features")
-        support_feature = ClimateEntityFeature(0)
+
+        support_feature = (
+            ClimateEntityFeature.TURN_ON
+            | ClimateEntityFeature.TURN_OFF
+        )
         if self.min_temp != 0.0 and self.max_temp != 0.0:
             support_feature = support_feature | ClimateEntityFeature.TARGET_TEMPERATURE
         if self.fan_modes:
@@ -604,3 +611,19 @@ class NatureRemoClimate(ClimateEntity):
         self._swing_mode = swing_mode
         self._button = ""
         self.async_write_ha_state()
+
+    async def async_turn_off(self):
+        """エアコンをOFFにする. / Turn off the air conditioner."""
+        await self.async_set_hvac_mode(HVACMode.OFF)
+
+    async def async_turn_on(self):
+        """エアコンをONにする. / Turn on the air conditioner."""
+        if self._hvac_mode != HVACMode.OFF:
+            await self.async_set_hvac_mode(self._hvac_mode)
+            return
+
+        if HVACMode.AUTO in self._hvac_modes:
+            await self.async_set_hvac_mode(HVACMode.AUTO)
+            return
+
+        _LOGGER.error("Unable to turn on")


### PR DESCRIPTION
Thank you for maintaining this project.

## Purpose

I would like to make the ClimateDevice controllable through the built-in intents `HassTurnOn` and `HassTurnOff`.

## Changes

Added `ClimateEntityFeature.TURN_ON` and `ClimateEntityFeature.TURN_OFF` to the ClimateDevice.

## Review points

There are two points I would especially appreciate feedback on:

- The HVAC mode applied when turning the device on
- The flag `self._enable_turn_on_off_backwards_compatibility = False`

### HVAC mode applied on TurnOn

For the TurnOn implementation, I assumed that the previous HVAC mode managed by Nature Remo is stored in `self._hvac_mode`, and the implementation switches back to that mode.

If the current mode is `OFF`, it switches to `AUTO` if available. If `AUTO` is not available, it logs an error message and does nothing.

I would appreciate feedback on whether this behavior is appropriate.

### Flag: `self._enable_turn_on_off_backwards_compatibility`

This flag appears to be intended for the migration period when the `TURN_ON` / `TURN_OFF` features were introduced.

https://developers.home-assistant.io/blog/2024/07/19/fan-fanentityfeatures-turn-on_off/

In my environment, `HassTurnOn` / `HassTurnOff` did not work unless this flag was set to `False`.

Since this flag is related to the `TURN_ON` / `TURN_OFF` features, I assumed that it would not affect other features.

## Verified behavior

I confirmed from Developer Tools > Actions that `climate.toggle`, which uses the `TURN_ON` / `TURN_OFF` features, works correctly.

```yaml
action: climate.toggle
target:
  entity_id:
    - climate.remo_lapis_nature_remo_living_ac
data: {}
```

I also confirmed that the device can be controlled from a voice agent using HassTurnOn and HassTurnOff.

## Thanks

Thanks to this integration, I was able to control my air conditioner from the AI agent feature of StackChan, an M5Stack-based communication robot.

https://x.com/74th/status/2050406148931764372


---

このプロジェクトをありがとうございます

## 目的

ClimateDeviceを、Built-in IntentのHassTurnOn、HassTurnOffで操作可能にしたい。

## 変更

ClimateDeviceに、ClimateEntityFeature.TURN_ON/TURN_OFFbを追加しました。

## レビュー観点

レビューで気にしていただきたいのは2点です。

- TurnOn時に適用するモードの仕様
- フラグ `self._enable_turn_on_off_backwards_compatibility = False`

### TurnOn時に適用するモード

TurnOnの実装については、Nature Remo側で管理している以前のHVACモードが self._hvac_mode にあるとして、そちらのモードに切り替える実装になっています。
OFFの場合は、AutoがあればAutoに、なければエラーメッセージを出力し、動作しないようになっています。
この仕様が適切かどうか考慮いただけると助かります。

### フラグ self._enable_turn_on_off_backwards_compatibility

このフラグは、TURN_ON/TURN_OFFのfeatureが導入された際の移行期間用のフラグのようです。

https://developers.home-assistant.io/blog/2024/07/19/fan-fanentityfeatures-turn-on_off/

現在もこのフラグがFalseになっていない場合、HassTurnOn/Offは動作しませんでした。

TURN_ON/TURN_OFFに関するフラグということで、他には影響しないと判断しました。

## 確認したこと

以下のTURN_ON/OFFのfeatureが使われるclimate.toggleが動作することを、DeveloperTool/Action で確認しました。

```
action: climate.toggle
target:
  entity_id:
    - climate.remo_lapis_nature_remo_living_ac
data: {}
```

また、HassTurnOn、HassTurnOffを利用する音声エージェントから利用し、動作することを確認しました。

## 感謝

StackChanというM5StackのコミュニケーションロボットのAIエージェント機能で、こちらのおかげでエアコンの操作ができるようになりました。

https://x.com/74th/status/2050406148931764372
